### PR TITLE
Fix tooltip provider and radio layout

### DIFF
--- a/app/(calc)/sample-size/clinical-trials/page.tsx
+++ b/app/(calc)/sample-size/clinical-trials/page.tsx
@@ -277,8 +277,18 @@ export default function ClinicalTrialsPage() {
                     <TabsContent value="superiority" className="space-y-6">
                         <FormField name="superiorityOutcome" render={({ field }) => (
                             <RadioGroup value={field.value} onValueChange={field.onChange} className="flex justify-center gap-4 p-2 bg-muted/50 rounded-lg">
-                                <FormItem><FormControl><RadioGroupItem value="binary" id="binary" className="sr-only" /><FormLabel htmlFor="binary" className={`cursor-pointer p-2 rounded-md ${field.value === 'binary' ? 'bg-primary text-primary-foreground' : 'bg-card'}`}>Binary Outcome</FormLabel></FormControl></FormItem>
-                                <FormItem><FormControl><RadioGroupItem value="continuous" id="continuous" className="sr-only" /><FormLabel htmlFor="continuous" className={`cursor-pointer p-2 rounded-md ${field.value === 'continuous' ? 'bg-primary text-primary-foreground' : 'bg-card'}`}>Continuous Outcome</FormLabel></FormControl></FormItem>
+                                <FormItem>
+                                    <FormControl>
+                                        <RadioGroupItem value="binary" id="binary" className="sr-only" />
+                                    </FormControl>
+                                    <FormLabel htmlFor="binary" className={`cursor-pointer p-2 rounded-md ${field.value === 'binary' ? 'bg-primary text-primary-foreground' : 'bg-card'}`}>Binary Outcome</FormLabel>
+                                </FormItem>
+                                <FormItem>
+                                    <FormControl>
+                                        <RadioGroupItem value="continuous" id="continuous" className="sr-only" />
+                                    </FormControl>
+                                    <FormLabel htmlFor="continuous" className={`cursor-pointer p-2 rounded-md ${field.value === 'continuous' ? 'bg-primary text-primary-foreground' : 'bg-card'}`}>Continuous Outcome</FormLabel>
+                                </FormItem>
                             </RadioGroup>
                         )} />
 

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 
 function TooltipProvider({
   delayDuration = 0,
+  children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
@@ -14,17 +15,20 @@ function TooltipProvider({
       data-slot="tooltip-provider"
       delayDuration={delayDuration}
       {...props}
-    />
+    >
+      {children}
+    </TooltipPrimitive.Provider>
   )
 }
 
 function Tooltip({
+  children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
+    <TooltipPrimitive.Root data-slot="tooltip" {...props}>
+      {children}
+    </TooltipPrimitive.Root>
   )
 }
 


### PR DESCRIPTION
## Summary
- ensure TooltipProvider wraps its children
- correct RadioGroup layout on clinical trials page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851f4e34138832bbd223ddbc0776719