### PR TITLE
Fix sidebar scroll and improve menu contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -114,8 +114,8 @@
     /* Sidebar colors - Dark theme */
     --sidebar: 215 19% 23%;
     --sidebar-foreground: 210 25% 98%;
-    --sidebar-primary: 220 70% 50%;
-    --sidebar-primary-foreground: 210 25% 98%;
+    --sidebar-primary: 220 70% 70%;
+    --sidebar-primary-foreground: 215 19% 23%;
     --sidebar-accent: 215 19% 28%;
     --sidebar-accent-foreground: 210 25% 98%;
     --sidebar-border: 215 19% 35%;

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -69,7 +69,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
           className={cn(
             "flex items-center gap-3 px-3 py-3 rounded-lg w-full text-left transition-all duration-200 group",
             isActive
-              ? "bg-primary text-primary-foreground shadow-sm"
+              ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm"
               : "hover:bg-accent hover:text-accent-foreground",
             isCollapsed && "justify-center px-2"
           )}
@@ -110,7 +110,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
         className={cn(
           "flex items-center gap-3 px-3 py-3 rounded-lg w-full transition-all duration-200 group",
           isActive
-            ? "bg-primary text-primary-foreground shadow-sm"
+            ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm"
             : "hover:bg-accent hover:text-accent-foreground",
           isCollapsed && "justify-center px-2"
         )}
@@ -352,7 +352,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
 
   return (
     <aside className={cn(
-      "fixed left-0 top-0 z-50 h-screen bg-sidebar border-r border-sidebar-border flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out",
+      "fixed left-0 top-0 z-50 h-screen bg-sidebar text-sidebar-foreground border-r border-sidebar-border flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out",
       isCollapsed ? "w-16" : "w-80"
     )}>
       <div className="flex flex-col h-full">
@@ -388,7 +388,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
         </div>
 
         {/* Main Navigation */}
-        <ScrollArea className="flex-1 px-3">
+        <ScrollArea className="flex-1 px-3 overflow-y-auto">
           <div className="space-y-2">
             {/* Favorites */}
             <SidebarFavorites isCollapsed={isCollapsed} />

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -82,7 +82,14 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
               <div className="flex-grow min-w-0">
                 <div className="font-medium truncate">{title || 'Unknown'}</div>
                 {description && (
-                  <div className="text-xs font-medium tracking-wide text-muted-foreground truncate">{description}</div>
+                  <div
+                    className={cn(
+                      "text-xs font-medium tracking-wide truncate",
+                      isActive ? "text-sidebar-primary-foreground" : "text-muted-foreground"
+                    )}
+                  >
+                    {description}
+                  </div>
                 )}
               </div>
               <div className="flex items-center gap-2">
@@ -122,7 +129,14 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
           <div className="flex-grow min-w-0">
             <div className="font-medium truncate">{title || 'Unknown'}</div>
             {description && (
-              <div className="text-xs font-medium tracking-wide text-muted-foreground truncate">{description}</div>
+              <div
+                className={cn(
+                  "text-xs font-medium tracking-wide truncate",
+                  isActive ? "text-sidebar-primary-foreground" : "text-muted-foreground"
+                )}
+              >
+                {description}
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- improve sidebar item active style to use sidebar-specific colors
- make sidebar scrollable and set text color for entire component
- tweak dark theme sidebar primary colors for higher contrast

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68524edfee28832ba624ab9d2ea5e364