### PR TITLE
Fix PDF extraction pipeline

### DIFF
--- a/lib/pdf-utils.ts
+++ b/lib/pdf-utils.ts
@@ -1,25 +1,57 @@
 'use client';
 
-export const extractTextFromPDF = async (arrayBuffer: ArrayBuffer): Promise<string> => {
-    // Dynamic import to prevent SSR issues
-    if (typeof window === 'undefined') {
-        throw new Error('PDF extraction is only available on the client side');
+export interface ExtractionPatterns {
+  [key: string]: RegExp[];
+}
+
+/**
+ * Extract plain text from a PDF document. The PDF.js worker is loaded
+ * dynamically so this function can run in the browser only.
+ */
+export const extractTextFromPDF = async (
+  arrayBuffer: ArrayBuffer,
+): Promise<string> => {
+  if (typeof window === 'undefined') {
+    throw new Error('PDF extraction is only available on the client side');
+  }
+
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf');
+  const workerSrc = (
+    await import('pdfjs-dist/legacy/build/pdf.worker.min?url')
+  ).default;
+  pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+
+  const pdf = await pdfjs.getDocument({ data: arrayBuffer }).promise;
+  let textContent = '';
+
+  for (let i = 1; i <= pdf.numPages; i++) {
+    const page = await pdf.getPage(i);
+    const text = await page.getTextContent();
+    textContent += text.items.map((s: any) => s.str || '').join(' ');
+  }
+
+  return textContent;
+};
+
+/**
+ * Extract numeric parameters from text using configured regex patterns.
+ */
+export const extractParameters = (
+  text: string,
+  patterns: ExtractionPatterns,
+): Record<string, number> => {
+  const results: Record<string, number> = {};
+  for (const [key, regexes] of Object.entries(patterns)) {
+    for (const regex of regexes) {
+      const match = text.match(regex);
+      if (match) {
+        const value = parseFloat(match[1]);
+        if (!Number.isNaN(value)) {
+          results[key] = value;
+          break;
+        }
+      }
     }
-
-    const pdfjs = await import('pdfjs-dist');
-
-    // Set the worker source
-    pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
-
-    const typedArray = new Uint8Array(arrayBuffer);
-    const pdf = await pdfjs.getDocument(typedArray).promise;
-    let textContent = '';
-
-    for (let i = 1; i <= pdf.numPages; i++) {
-        const page = await pdf.getPage(i);
-        const text = await page.getTextContent();
-        textContent += text.items.map((s: any) => s.str || '').join(' ');
-    }
-
-    return textContent;
+  }
+  return results;
 };

--- a/pdfjs-dist.d.ts
+++ b/pdfjs-dist.d.ts
@@ -1,0 +1,2 @@
+declare module 'pdfjs-dist/legacy/build/pdf';
+declare module 'pdfjs-dist/legacy/build/pdf.worker.min?url';


### PR DESCRIPTION
## Summary
- refactor PDF utilities for reliable client-side parsing
- add generic parameter extraction helper
- use new helpers in sample size tools and t-test form

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852611a9940832bb522f1dfe20ff1a0