### PR TITLE
Fix NaN outputs in sample size tools

### DIFF
--- a/lib/clinicalTrial.ts
+++ b/lib/clinicalTrial.ts
@@ -17,7 +17,7 @@ export const SuperiorityBinarySchema = z.object({
     alpha: z.enum(['1', '5', '10']).transform(val => Number(val)),
     power: z.enum(['80', '85', '90', '95']).transform(val => Number(val)),
     allocationRatio: z.number().positive(),
-    dropoutRate: z.number().min(0).max(100),
+    dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100'),
 }).refine((data: { treatmentRate: number; controlRate: number; }) => data.treatmentRate > data.controlRate, {
     message: "Treatment rate must be greater than control rate.",
     path: ["treatmentRate"],
@@ -38,7 +38,7 @@ export const SuperiorityContinuousSchema = z.object({
     alpha: z.enum(['1', '5', '10']).transform(val => Number(val)),
     power: z.enum(['80', '85', '90', '95']).transform(val => Number(val)),
     allocationRatio: z.number().positive(),
-    dropoutRate: z.number().min(0).max(100),
+    dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100'),
 });
 
 export type SuperiorityContinuousInput = z.infer<typeof SuperiorityContinuousSchema>;
@@ -57,7 +57,7 @@ export const NonInferioritySchema = z.object({
     alpha: z.enum(['1', '5', '10']).transform(val => Number(val)),
     power: z.enum(['80', '85', '90', '95']).transform(val => Number(val)),
     allocationRatio: z.number().positive(),
-    dropoutRate: z.number().min(0).max(100),
+    dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100'),
 });
 
 export type NonInferiorityInput = z.infer<typeof NonInferioritySchema>;
@@ -75,7 +75,7 @@ export const EquivalenceSchema = z.object({
     alpha: z.enum(['1', '5', '10']).transform(val => Number(val)),
     power: z.enum(['80', '85', '90', '95']).transform(val => Number(val)),
     allocationRatio: z.number().positive(),
-    dropoutRate: z.number().min(0).max(100),
+    dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100'),
 }).refine((data: { margin: number; testRate: number; referenceRate: number; }) => data.margin > Math.abs(data.testRate - data.referenceRate), {
     message: "Equivalence margin must be larger than the expected difference.",
     path: ["margin"],

--- a/lib/comparativeStudy.ts
+++ b/lib/comparativeStudy.ts
@@ -11,7 +11,7 @@ export const CaseControlParamsSchema = z.object({
   power: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Power must be 0.80, 0.85, 0.90, or 0.95'
   }).optional(),
-  nonResponseRate: z.number().min(0).max(100, 'Non-response rate must be between 0 and 100').optional(),
+  nonResponseRate: z.number().min(0).max(99.9, 'Non-response rate must be less than 100').optional(),
 });
 
 export const CohortParamsSchema = z.object({
@@ -24,7 +24,7 @@ export const CohortParamsSchema = z.object({
   power: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Power must be 0.80, 0.85, 0.90, or 0.95'
   }).optional(),
-  lossToFollowUp: z.number().min(0).max(100, 'Loss to follow-up must be between 0 and 100').optional(),
+  lossToFollowUp: z.number().min(0).max(99.9, 'Loss to follow-up must be less than 100').optional(),
 });
 
 export const ComparativeStudyParamsSchema = z.object({
@@ -34,7 +34,7 @@ export const ComparativeStudyParamsSchema = z.object({
   statisticalPower: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Statistical power must be 0.80, 0.85, 0.90, or 0.95'
   }),
-  nonResponseRate: z.number().min(0).max(100, 'Non-response rate must be between 0 and 100'),
+  nonResponseRate: z.number().min(0).max(99.9, 'Non-response rate must be less than 100'),
   allocationRatio: z.number().positive('Allocation ratio must be positive'),
   // Case-Control specific
   controlExposure: z.number().min(0.1).max(99.9).optional(),
@@ -120,8 +120,8 @@ export function calculateCaseControl(params: CaseControlParams) {
     const n_cases = Math.pow(za * Math.sqrt((1 + 1/caseControlRatio) * p_bar * (1 - p_bar)) + zb * Math.sqrt(p1*(1-p1) + (p0*(1-p0))/caseControlRatio), 2) / Math.pow(p1 - p0, 2);
     const n_controls = caseControlRatio * n_cases;
 
-    const total_n_cases = Math.ceil(n_cases / (1 - nonResponseRate/100));
-    const total_n_controls = Math.ceil(n_controls / (1 - nonResponseRate/100));
+    const total_n_cases = nonResponseRate >= 100 ? Infinity : Math.ceil(n_cases / (1 - nonResponseRate/100));
+    const total_n_controls = nonResponseRate >= 100 ? Infinity : Math.ceil(n_controls / (1 - nonResponseRate/100));
 
     return {
         cases: total_n_cases,
@@ -155,8 +155,8 @@ export function calculateCohort(params: CohortParams) {
     const n_unexposed = Math.pow(za * Math.sqrt((1 + 1/exposedUnexposedRatio) * p_bar * (1 - p_bar)) + zb * Math.sqrt(p1*(1-p1)/exposedUnexposedRatio + p0*(1-p0)), 2) / Math.pow(p1 - p0, 2);
     const n_exposed = exposedUnexposedRatio * n_unexposed;
 
-    const total_n_unexposed = Math.ceil(n_unexposed / (1 - lossToFollowUp/100));
-    const total_n_exposed = Math.ceil(n_exposed / (1 - lossToFollowUp/100));
+    const total_n_unexposed = lossToFollowUp >= 100 ? Infinity : Math.ceil(n_unexposed / (1 - lossToFollowUp/100));
+    const total_n_exposed = lossToFollowUp >= 100 ? Infinity : Math.ceil(n_exposed / (1 - lossToFollowUp/100));
 
     return {
         exposed: total_n_exposed,

--- a/lib/crossSectional.ts
+++ b/lib/crossSectional.ts
@@ -19,7 +19,7 @@ export const CrossSectionalSchema = z.object({
     }),
     populationSize: z.number().positive().optional(),
     designEffect: z.number().min(1),
-    nonResponseRate: z.number().min(0).max(100),
+    nonResponseRate: z.number().min(0).max(99.9, 'Non-response rate must be less than 100'),
     clusteringEffect: z.number().min(0).max(1),
 });
 
@@ -72,7 +72,9 @@ export function calculateCrossSectionalSampleSize(params: CrossSectionalInput): 
     }
 
     // 5. Adjust for Non-Response Rate
-    const finalSize = clusterAdjustedSize / (1 - (nonResponseRate / 100));
+    const finalSize = nonResponseRate >= 100
+        ? Infinity
+        : clusterAdjustedSize / (1 - (nonResponseRate / 100));
 
     return {
         baseSize: Math.ceil(baseSize),

--- a/lib/survivalAnalysis.ts
+++ b/lib/survivalAnalysis.ts
@@ -84,7 +84,7 @@ export const LogRankParamsSchema = z.object({
   power: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Power must be 0.80, 0.85, 0.90, or 0.95'
   }).optional(),
-  dropoutRate: z.number().min(0).max(100, 'Dropout rate must be between 0 and 100').optional(),
+  dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100').optional(),
 });
 
 export const CoxParamsSchema = z.object({
@@ -99,7 +99,7 @@ export const CoxParamsSchema = z.object({
   power: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Power must be 0.80, 0.85, 0.90, or 0.95'
   }).optional(),
-  dropoutRate: z.number().min(0).max(100, 'Dropout rate must be between 0 and 100').optional(),
+  dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100').optional(),
   allocationRatio: z.number().positive('Allocation ratio must be positive').optional(),
 });
 
@@ -113,7 +113,7 @@ export const OneArmParamsSchema = z.object({
   power: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Power must be 0.80, 0.85, 0.90, or 0.95'
   }).optional(),
-  dropoutRate: z.number().min(0).max(100, 'Dropout rate must be between 0 and 100').optional(),
+  dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100').optional(),
 });
 
 export const SurvivalAnalysisParamsSchema = z.object({
@@ -129,7 +129,7 @@ export const SurvivalAnalysisParamsSchema = z.object({
   statisticalPower: z.number().refine(val => [0.80, 0.85, 0.90, 0.95].includes(val), {
     message: 'Statistical power must be 0.80, 0.85, 0.90, or 0.95'
   }),
-  dropoutRate: z.number().min(0).max(100, 'Dropout rate must be between 0 and 100'),
+  dropoutRate: z.number().min(0).max(99.9, 'Dropout rate must be less than 100'),
 });
 
 export type LogRankInput = z.infer<typeof LogRankParamsSchema>;
@@ -168,7 +168,7 @@ export class SurvivalAnalysis {
     const n1 = totalEvents / (probEvent1 + allocationRatio * probEvent2);
     const n2 = allocationRatio * n1;
 
-    const totalSampleSize = Math.ceil(n1 + n2) / (1 - dropoutRate/100);
+    const totalSampleSize = dropoutRate >= 100 ? Infinity : Math.ceil(n1 + n2) / (1 - dropoutRate/100);
 
     // Calculate group sizes
     const group1SampleSize = Math.ceil(totalSampleSize / (1 + allocationRatio));
@@ -209,7 +209,9 @@ export class SurvivalAnalysis {
     const zb = z_beta[power.toString() as keyof typeof z_beta];
 
     const totalEvents = Math.pow(za + zb, 2) / (Math.pow(Math.log(hazardRatio), 2) * (1 - rSquared));
-    const totalSampleSize = Math.ceil(totalEvents / overallEventRate / (1 - dropoutRate/100));
+    const totalSampleSize = dropoutRate >= 100
+        ? Infinity
+        : Math.ceil(totalEvents / overallEventRate / (1 - dropoutRate/100));
 
     // Calculate group sizes
     const group1SampleSize = Math.round(totalSampleSize / (1 + allocationRatio));
@@ -258,7 +260,9 @@ export class SurvivalAnalysis {
     const numerator = Math.pow(za * Math.sqrt(p0 * (1 - p0)) + zb * Math.sqrt(p1 * (1 - p1)), 2);
     const denominator = Math.pow(p1 - p0, 2);
 
-    const totalSampleSize = numerator / denominator / (1 - dropoutRate/100);
+    const totalSampleSize = dropoutRate >= 100
+        ? Infinity
+        : numerator / denominator / (1 - dropoutRate/100);
 
     // Calculate group sizes
     const group1SampleSize = Math.ceil(totalSampleSize / (1 + targetMedianSurvival / historicalMedianSurvival));


### PR DESCRIPTION
## Summary
- tighten validation rules for dropout and non-response rates
- guard calculations against 100% rates to avoid NaN/Infinity

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685261d344b8832b8ef95d3f19c9600b