### PR TITLE
Fix survival analysis NaN

### DIFF
--- a/app/(calc)/sample-size/survival/page.tsx
+++ b/app/(calc)/sample-size/survival/page.tsx
@@ -85,8 +85,8 @@ export default function SurvivalAnalysisPage() {
       title = "Log-Rank Test Results";
       resultItems = [
         { label: 'Total Sample Size', value: results.totalSampleSize, category: 'primary' as const, highlight: true, format: 'integer' as const },
-        { label: 'Sample Size Group 1', value: results.n1, category: 'secondary' as const, format: 'integer' as const },
-        { label: 'Sample Size Group 2', value: results.n2, category: 'secondary' as const, format: 'integer' as const },
+        { label: 'Sample Size Group 1', value: results.group1SampleSize, category: 'secondary' as const, format: 'integer' as const },
+        { label: 'Sample Size Group 2', value: results.group2SampleSize, category: 'secondary' as const, format: 'integer' as const },
         { label: 'Total Events Required', value: results.totalEvents, category: 'statistical' as const, format: 'integer' as const },
       ];
     } else if (activeTab === "cox") {

--- a/lib/survivalAnalysis.ts
+++ b/lib/survivalAnalysis.ts
@@ -152,8 +152,8 @@ export class SurvivalAnalysis {
         dropoutRate = 0
     } = params;
 
-    const za = z_alpha[significanceLevel.toString() as keyof typeof z_alpha];
-    const zb = z_beta[power.toString() as keyof typeof z_beta];
+    const za = z_alpha[significanceLevel.toFixed(2) as keyof typeof z_alpha];
+    const zb = z_beta[power.toFixed(2) as keyof typeof z_beta];
 
     const lambda1 = this.LN2 / medianSurvival1;
     const lambda2 = this.LN2 / medianSurvival2;
@@ -205,8 +205,8 @@ export class SurvivalAnalysis {
         followupPeriod,
     } = params;
 
-    const za = z_alpha[significanceLevel.toString() as keyof typeof z_alpha];
-    const zb = z_beta[power.toString() as keyof typeof z_beta];
+    const za = z_alpha[significanceLevel.toFixed(2) as keyof typeof z_alpha];
+    const zb = z_beta[power.toFixed(2) as keyof typeof z_beta];
 
     const totalEvents = Math.pow(za + zb, 2) / (Math.pow(Math.log(hazardRatio), 2) * (1 - rSquared));
     const totalSampleSize = dropoutRate >= 100
@@ -248,8 +248,8 @@ export class SurvivalAnalysis {
         dropoutRate = 0
     } = params;
 
-    const za = z_alpha[significanceLevel.toString() as keyof typeof z_alpha];
-    const zb = z_beta[power.toString() as keyof typeof z_beta];
+    const za = z_alpha[significanceLevel.toFixed(2) as keyof typeof z_alpha];
+    const zb = z_beta[power.toFixed(2) as keyof typeof z_beta];
 
     const lambda0 = this.LN2 / historicalMedianSurvival;
     const lambda1 = this.LN2 / targetMedianSurvival;


### PR DESCRIPTION
## Summary
- fix z-score lookup for survival sample size calculations
- show group sample sizes correctly in survival results

## Testing
- `npm install`
- `npm run build`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6853a614017c832bb53dfedc3d1b1531