### PR TITLE
Improve calculator tabs and add chart options

### DIFF
--- a/app/(calc)/sample-size/comparative/page.tsx
+++ b/app/(calc)/sample-size/comparative/page.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import { CaseControlForm } from "@/components/sample-size/CaseControlForm";
 import { CohortForm } from "@/components/sample-size/CohortForm";
 import { ToolPageWrapper } from '@/components/ui/tool-page-wrapper';
-import { EnhancedTabs } from '@/components/ui/enhanced-tabs';
+import {
+  EnhancedTabs,
+  EnhancedTabsList,
+  EnhancedTabsTrigger,
+  EnhancedTabsContent,
+} from '@/components/ui/enhanced-tabs';
 import { EnhancedResultsDisplay } from '@/components/ui/enhanced-results-display';
 import { AdvancedVisualization } from '@/components/ui/advanced-visualization';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -50,14 +55,28 @@ export default function ComparativeStudyPage() {
       <EnhancedTabs
         value={activeTab}
         onValueChange={setActiveTab}
-        className="w-full"
+        className="space-y-4"
       >
-        {activeTab === "case-control" && (
+        <EnhancedTabsList className="grid w-full grid-cols-2" variant="modern">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <EnhancedTabsTrigger key={tab.value} value={tab.value} variant="modern">
+                <div className="flex items-center gap-2">
+                  <Icon className="h-4 w-4" />
+                  <span>{tab.label}</span>
+                </div>
+              </EnhancedTabsTrigger>
+            );
+          })}
+        </EnhancedTabsList>
+
+        <EnhancedTabsContent value="case-control">
           <CaseControlForm onResultsChange={setResults} />
-        )}
-        {activeTab === "cohort" && (
+        </EnhancedTabsContent>
+        <EnhancedTabsContent value="cohort">
           <CohortForm onResultsChange={setResults} />
-        )}
+        </EnhancedTabsContent>
       </EnhancedTabs>
     </div>
   );

--- a/app/(calc)/sample-size/survival/page.tsx
+++ b/app/(calc)/sample-size/survival/page.tsx
@@ -7,7 +7,12 @@ import { OneArmSurvivalForm } from "@/components/sample-size/OneArmSurvivalForm"
 import { ToolPageWrapper } from '@/components/ui/tool-page-wrapper';
 import { EnhancedResultsDisplay } from '@/components/ui/enhanced-results-display';
 import { AdvancedVisualization } from '@/components/ui/advanced-visualization';
-import { EnhancedTabs } from '@/components/ui/enhanced-tabs';
+import {
+  EnhancedTabs,
+  EnhancedTabsList,
+  EnhancedTabsTrigger,
+  EnhancedTabsContent,
+} from '@/components/ui/enhanced-tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Clock, Target, Activity } from 'lucide-react';
 
@@ -41,9 +46,23 @@ export default function SurvivalAnalysisPage() {
       <EnhancedTabs
         value={activeTab}
         onValueChange={setActiveTab}
-        className="w-full"
+        className="space-y-4"
       >
-        {activeTab === "log-rank" && (
+        <EnhancedTabsList className="grid w-full grid-cols-3" variant="modern">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <EnhancedTabsTrigger key={tab.value} value={tab.value} variant="modern">
+                <div className="flex items-center gap-2">
+                  <Icon className="h-4 w-4" />
+                  <span>{tab.label}</span>
+                </div>
+              </EnhancedTabsTrigger>
+            );
+          })}
+        </EnhancedTabsList>
+
+        <EnhancedTabsContent value="log-rank">
           <Card>
             <CardHeader>
               <CardTitle>Log-Rank Test Sample Size</CardTitle>
@@ -55,9 +74,9 @@ export default function SurvivalAnalysisPage() {
               <LogRankForm onResultsChange={setResults} />
             </CardContent>
           </Card>
-        )}
+        </EnhancedTabsContent>
 
-        {activeTab === "cox" && (
+        <EnhancedTabsContent value="cox">
           <Card>
             <CardHeader>
               <CardTitle>Cox Proportional Hazards Sample Size</CardTitle>
@@ -69,9 +88,9 @@ export default function SurvivalAnalysisPage() {
               <CoxRegressionForm onResultsChange={setResults} />
             </CardContent>
           </Card>
-        )}
+        </EnhancedTabsContent>
 
-        {activeTab === "one-arm" && (
+        <EnhancedTabsContent value="one-arm">
           <Card>
             <CardHeader>
               <CardTitle>One-Arm Survival Study Sample Size</CardTitle>
@@ -83,7 +102,7 @@ export default function SurvivalAnalysisPage() {
               <OneArmSurvivalForm onResultsChange={setResults} />
             </CardContent>
           </Card>
-        )}
+        </EnhancedTabsContent>
       </EnhancedTabs>
     </div>
   );

--- a/components/disease-math/MetricsDisplay.tsx
+++ b/components/disease-math/MetricsDisplay.tsx
@@ -19,17 +19,24 @@ const formatNumber = (value: number) => {
 };
 
 export function MetricsDisplay({ results, animated = true }: MetricsDisplayProps) {
-  // Transform the results into the format expected by StatisticalSummary
+  const populationSize =
+    (results.susceptible?.[0] || 0) +
+    (results.exposed?.[0] || 0) +
+    (results.infected?.[0] || 0) +
+    (results.recovered?.[0] || 0) +
+    (results.deceased?.[0] || 0) +
+    (results.vaccinated?.[0] || 0);
+
   const diseaseModelResults = {
     metrics: {
       peakInfected: Math.round(results.peakInfection),
       r0: results.r0,
-      attackRate: results.totalCases / (((results as any).populationSize) || 100000), // Assuming population size
+      attackRate: results.totalCases / (populationSize || 1),
       totalDeaths: Math.round(results.totalDeaths),
       mortalityRate: results.totalDeaths / results.totalCases,
       peakDay: results.peakDay
     },
-    populationSize: (results as any).populationSize || 100000
+    populationSize
   };
 
   return (

--- a/lib/regression.ts
+++ b/lib/regression.ts
@@ -129,6 +129,7 @@ export interface LogisticRegressionResult {
     aic: number;
     iterations: number;
     chartData?: any;
+    chartOptions?: any;
     chartComponent?: React.ReactNode;
 }
 
@@ -220,6 +221,7 @@ export interface MultipleRegressionResult {
   X: number[][];
   y: number[];
   chartData?: any;
+  chartOptions?: any;
   chartComponent?: React.ReactNode;
 }
 


### PR DESCRIPTION
## Summary
- fix tab lists for Comparative Study calculator
- fix tab lists for Survival calculator
- support optional `chartOptions` in regression result interfaces
- compute population size dynamically in disease model metrics display

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685815656730832b99320a32e2dd9481