### PR TITLE
Fix numeric validation issues

### DIFF
--- a/app/(calc)/sample-size/clinical-trials/page.tsx
+++ b/app/(calc)/sample-size/clinical-trials/page.tsx
@@ -71,8 +71,8 @@ export default function ClinicalTrialsPage() {
         resolver: zodResolver(FormSchema),
         defaultValues: {
             superiorityOutcome: 'binary',
-            alpha: '5',
-            power: '80',
+            alpha: 5,
+            power: 80,
             allocationRatio: 1,
             dropoutRate: 15,
             // Superiority Binary - Realistic clinical trial scenario (success rates)

--- a/app/(calc)/sample-size/clinical-trials/page.tsx
+++ b/app/(calc)/sample-size/clinical-trials/page.tsx
@@ -45,8 +45,8 @@ type Results = SuperiorityBinaryOutput | SuperiorityContinuousOutput | NonInferi
 const FormSchema = z.object({
     superiorityOutcome: z.enum(['binary', 'continuous']).optional(),
     // Allow all fields to be optional for the combined form
-    alpha: z.string().optional(),
-    power: z.string().optional(),
+    alpha: z.number().optional(),
+    power: z.number().optional(),
     allocationRatio: z.number().optional(),
     dropoutRate: z.number().optional(),
     // Superiority binary

--- a/app/(calc)/sample-size/diagnostic/page.tsx
+++ b/app/(calc)/sample-size/diagnostic/page.tsx
@@ -99,8 +99,8 @@ export default function DiagnosticTestPage() {
             // Convert all relevant fields to numbers before validation
             const processedData = {
                 ...data,
-                alpha: data.alpha !== undefined && data.alpha !== '' ? Number(data.alpha) : undefined,
-                power: data.power !== undefined && data.power !== '' ? Number(data.power) : undefined,
+                alpha: data.alpha !== undefined ? Number(data.alpha) : undefined,
+                power: data.power !== undefined ? Number(data.power) : undefined,
                 expectedSensitivity: data.expectedSensitivity ? Number(data.expectedSensitivity) : undefined,
                 expectedSpecificity: data.expectedSpecificity ? Number(data.expectedSpecificity) : undefined,
                 diseasePrevalence: data.diseasePrevalence ? Number(data.diseasePrevalence) : undefined,
@@ -565,7 +565,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -585,7 +585,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -613,7 +613,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -639,7 +639,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -663,7 +663,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -732,7 +732,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -752,7 +752,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -776,7 +776,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -812,7 +812,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -835,7 +835,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -859,7 +859,7 @@ export default function DiagnosticTestPage() {
                                                     onChange={(e) =>
                                                         field.onChange(
                                                             e.target.value === ''
-                                                                ? ''
+                                                                ? undefined
                                                                 : parseFloat(e.target.value)
                                                         )
                                                     }
@@ -893,7 +893,7 @@ export default function DiagnosticTestPage() {
                                             onChange={(e) =>
                                                 field.onChange(
                                                     e.target.value === ''
-                                                        ? ''
+                                                        ? undefined
                                                         : parseFloat(e.target.value)
                                                 )
                                             }
@@ -914,7 +914,7 @@ export default function DiagnosticTestPage() {
                                             onChange={(e) =>
                                                 field.onChange(
                                                     e.target.value === ''
-                                                        ? ''
+                                                        ? undefined
                                                         : parseFloat(e.target.value)
                                                 )
                                             }
@@ -938,7 +938,7 @@ export default function DiagnosticTestPage() {
                                             onChange={(e) =>
                                                 field.onChange(
                                                     e.target.value === ''
-                                                        ? ''
+                                                        ? undefined
                                                         : parseFloat(e.target.value)
                                                 )
                                             }

--- a/app/(calc)/sample-size/diagnostic/page.tsx
+++ b/app/(calc)/sample-size/diagnostic/page.tsx
@@ -72,7 +72,7 @@ export default function DiagnosticTestPage() {
             expectedSpecificity: 90, // 90% specificity (good specificity)
             diseasePrevalence: 20, // 20% prevalence (moderate prevalence)
             marginOfError: 5, // 5% margin of error (typical precision)
-            alpha: '5', // 5% alpha level
+            alpha: 5, // 5% alpha level
             dropoutRate: 10, // 10% dropout rate
             // Comparative
             studyDesign: 'paired',
@@ -80,7 +80,7 @@ export default function DiagnosticTestPage() {
             test1Performance: 80, // 80% performance for test 1
             test2Performance: 90, // 90% performance for test 2 (detectable difference)
             testCorrelation: 0.5, // Moderate correlation
-            power: '80', // 80% power
+            power: 80, // 80% power
             // ROC
             expectedAUC: 0.80, // 80% AUC (good discriminative ability)
             nullAUC: 0.5, // 50% null hypothesis
@@ -558,7 +558,18 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Expected Sensitivity (%)</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -567,7 +578,18 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Expected Specificity (%)</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -583,7 +605,19 @@ export default function DiagnosticTestPage() {
                                                 <FormLabel>Disease Prevalence (%)</FormLabel>
                                             </FieldPopover>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} className="w-full" />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    className="w-full"
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -597,7 +631,19 @@ export default function DiagnosticTestPage() {
                                                 <FormLabel>Margin of Error (%)</FormLabel>
                                             </FieldPopover>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} className="w-full" />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    className="w-full"
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -609,7 +655,19 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Confidence Level (%)</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="1" {...field} className="w-full" />
+                                                <Input
+                                                    type="number"
+                                                    step="1"
+                                                    {...field}
+                                                    className="w-full"
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -667,7 +725,18 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Test 1 Performance (%)</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -676,7 +745,18 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Test 2 Performance (%)</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -687,7 +767,20 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Test Correlation</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.01" min="0" max="1" {...field} />
+                                                <Input
+                                                    type="number"
+                                                    step="0.01"
+                                                    min="0"
+                                                    max="1"
+                                                    {...field}
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -709,7 +802,21 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Expected AUC</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.01" min="0" max="1" {...field} className="w-full" />
+                                                <Input
+                                                    type="number"
+                                                    step="0.01"
+                                                    min="0"
+                                                    max="1"
+                                                    {...field}
+                                                    className="w-full"
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -718,7 +825,21 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Null AUC</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.01" min="0" max="1" {...field} className="w-full" />
+                                                <Input
+                                                    type="number"
+                                                    step="0.01"
+                                                    min="0"
+                                                    max="1"
+                                                    {...field}
+                                                    className="w-full"
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -730,7 +851,19 @@ export default function DiagnosticTestPage() {
                                         <FormItem>
                                             <FormLabel>Negative:Positive Ratio</FormLabel>
                                             <FormControl>
-                                                <Input type="number" step="0.1" {...field} className="w-full" />
+                                                <Input
+                                                    type="number"
+                                                    step="0.1"
+                                                    {...field}
+                                                    className="w-full"
+                                                    onChange={(e) =>
+                                                        field.onChange(
+                                                            e.target.value === ''
+                                                                ? ''
+                                                                : parseFloat(e.target.value)
+                                                        )
+                                                    }
+                                                />
                                             </FormControl>
                                             <FormMessage />
                                         </FormItem>
@@ -752,7 +885,19 @@ export default function DiagnosticTestPage() {
                                 <FormItem>
                                     <FormLabel>Significance Level (%)</FormLabel>
                                     <FormControl>
-                                        <Input type="number" step="0.1" {...field} className="w-full" />
+                                        <Input
+                                            type="number"
+                                            step="0.1"
+                                            {...field}
+                                            className="w-full"
+                                            onChange={(e) =>
+                                                field.onChange(
+                                                    e.target.value === ''
+                                                        ? ''
+                                                        : parseFloat(e.target.value)
+                                                )
+                                            }
+                                        />
                                     </FormControl>
                                     <FormMessage />
                                 </FormItem>
@@ -761,7 +906,19 @@ export default function DiagnosticTestPage() {
                                 <FormItem>
                                     <FormLabel>Power (%)</FormLabel>
                                     <FormControl>
-                                        <Input type="number" step="1" {...field} className="w-full" />
+                                        <Input
+                                            type="number"
+                                            step="1"
+                                            {...field}
+                                            className="w-full"
+                                            onChange={(e) =>
+                                                field.onChange(
+                                                    e.target.value === ''
+                                                        ? ''
+                                                        : parseFloat(e.target.value)
+                                                )
+                                            }
+                                        />
                                     </FormControl>
                                     <FormMessage />
                                 </FormItem>
@@ -773,7 +930,19 @@ export default function DiagnosticTestPage() {
                                 <FormItem>
                                     <FormLabel>Dropout Rate (%)</FormLabel>
                                     <FormControl>
-                                        <Input type="number" step="0.1" {...field} className="w-full" />
+                                        <Input
+                                            type="number"
+                                            step="0.1"
+                                            {...field}
+                                            className="w-full"
+                                            onChange={(e) =>
+                                                field.onChange(
+                                                    e.target.value === ''
+                                                        ? ''
+                                                        : parseFloat(e.target.value)
+                                                )
+                                            }
+                                        />
                                     </FormControl>
                                     <FormMessage />
                                 </FormItem>

--- a/app/(calc)/sample-size/diagnostic/page.tsx
+++ b/app/(calc)/sample-size/diagnostic/page.tsx
@@ -44,7 +44,7 @@ const FormSchema = z.object({
     expectedSpecificity: z.number().min(1, "Specificity must be at least 1%").max(100, "Specificity cannot exceed 100%").optional(),
     diseasePrevalence: z.number().min(0.1, "Prevalence must be at least 0.1%").max(99.9, "Prevalence cannot exceed 99.9%").optional(),
     marginOfError: z.number().min(0.1, "Margin of error must be at least 0.1%").max(50, "Margin of error cannot exceed 50%").optional(),
-    alpha: z.string().min(1, "Alpha level is required").optional(),
+    alpha: z.number().min(1, "Alpha level is required").optional(),
     dropoutRate: z.number().min(0, "Dropout rate cannot be negative").max(50, "Dropout rate cannot exceed 50%").optional(),
     // Comparative
     studyDesign: z.enum(['paired', 'unpaired']).optional(),
@@ -52,7 +52,7 @@ const FormSchema = z.object({
     test1Performance: z.number().min(1, "Test 1 performance must be at least 1%").max(100, "Test 1 performance cannot exceed 100%").optional(),
     test2Performance: z.number().min(1, "Test 2 performance must be at least 1%").max(100, "Test 2 performance cannot exceed 100%").optional(),
     testCorrelation: z.number().min(0, "Correlation cannot be negative").max(1, "Correlation cannot exceed 1").optional(),
-    power: z.string().min(1, "Power is required").optional(),
+    power: z.number().min(1, "Power is required").optional(),
     // ROC
     expectedAUC: z.number().min(0.5, "AUC must be at least 0.5").max(1, "AUC cannot exceed 1").optional(),
     nullAUC: z.number().min(0.5, "Null AUC must be at least 0.5").max(1, "Null AUC cannot exceed 1").optional(),
@@ -99,8 +99,8 @@ export default function DiagnosticTestPage() {
             // Convert all relevant fields to numbers before validation
             const processedData = {
                 ...data,
-                alpha: data.alpha ? parseFloat(data.alpha) : undefined,
-                power: data.power ? parseFloat(data.power) : undefined,
+                alpha: data.alpha !== undefined && data.alpha !== '' ? Number(data.alpha) : undefined,
+                power: data.power !== undefined && data.power !== '' ? Number(data.power) : undefined,
                 expectedSensitivity: data.expectedSensitivity ? Number(data.expectedSensitivity) : undefined,
                 expectedSpecificity: data.expectedSpecificity ? Number(data.expectedSpecificity) : undefined,
                 diseasePrevalence: data.diseasePrevalence ? Number(data.diseasePrevalence) : undefined,

--- a/app/(calc)/sample-size/t-test/page.tsx
+++ b/app/(calc)/sample-size/t-test/page.tsx
@@ -82,8 +82,8 @@ export default function TTestPage() {
       // Convert all relevant fields to numbers before validation
       const processedData = {
         ...data,
-        alpha: parseFloat(data.alpha || '0'),
-        power: parseFloat(data.power || '0'),
+        alpha: data.alpha !== undefined && data.alpha !== '' ? Number(data.alpha) : undefined,
+        power: data.power !== undefined && data.power !== '' ? Number(data.power) : undefined,
         group1Mean: data.group1Mean ? Number(data.group1Mean) : undefined,
         group2Mean: data.group2Mean ? Number(data.group2Mean) : undefined,
         pooledSD: data.pooledSD ? Number(data.pooledSD) : undefined,
@@ -189,8 +189,8 @@ export default function TTestPage() {
           { label: "Group 2 Mean", value: formData.group2Mean },
           { label: "Pooled Standard Deviation", value: formData.pooledSD },
           { label: "Allocation Ratio", value: formData.allocationRatio },
-          { label: "Significance Level", value: parseFloat(formData.alpha || '5'), unit: "%" },
-          { label: "Statistical Power", value: parseFloat(formData.power || '80'), unit: "%" }
+          { label: "Significance Level", value: Number(formData.alpha ?? 5), unit: "%" },
+          { label: "Statistical Power", value: Number(formData.power ?? 80), unit: "%" }
         ];
         config.results = [
           { label: "Total Sample Size", value: results.totalSize, highlight: true, category: "primary", format: "integer" },
@@ -206,8 +206,8 @@ export default function TTestPage() {
           { label: "Expected Mean Difference", value: formData.meanDifference },
           { label: "Standard Deviation of Differences", value: formData.sdDifference },
           { label: "Correlation between Pairs", value: formData.correlation },
-          { label: "Significance Level", value: parseFloat(formData.alpha || '5'), unit: "%" },
-          { label: "Statistical Power", value: parseFloat(formData.power || '80'), unit: "%" }
+          { label: "Significance Level", value: Number(formData.alpha ?? 5), unit: "%" },
+          { label: "Statistical Power", value: Number(formData.power ?? 80), unit: "%" }
         ];
         config.results = [
           { label: "Required Number of Pairs", value: results.pairsSize, highlight: true, category: "primary", format: "integer" },
@@ -222,8 +222,8 @@ export default function TTestPage() {
           { label: "Expected Sample Mean", value: formData.sampleMean },
           { label: "Population Mean (H₀)", value: formData.populationMean },
           { label: "Population Standard Deviation", value: formData.populationSD },
-          { label: "Significance Level", value: parseFloat(formData.alpha || '5'), unit: "%" },
-          { label: "Statistical Power", value: parseFloat(formData.power || '80'), unit: "%" }
+          { label: "Significance Level", value: Number(formData.alpha ?? 5), unit: "%" },
+          { label: "Statistical Power", value: Number(formData.power ?? 80), unit: "%" }
         ];
         config.results = [
           { label: "Required Sample Size", value: results.sampleSize, highlight: true, category: "primary", format: "integer" },

--- a/app/(calc)/sample-size/t-test/page.tsx
+++ b/app/(calc)/sample-size/t-test/page.tsx
@@ -82,8 +82,8 @@ export default function TTestPage() {
       // Convert all relevant fields to numbers before validation
       const processedData = {
         ...data,
-        alpha: data.alpha !== undefined && data.alpha !== '' ? Number(data.alpha) : undefined,
-        power: data.power !== undefined && data.power !== '' ? Number(data.power) : undefined,
+        alpha: data.alpha !== undefined ? Number(data.alpha) : undefined,
+        power: data.power !== undefined ? Number(data.power) : undefined,
         group1Mean: data.group1Mean ? Number(data.group1Mean) : undefined,
         group2Mean: data.group2Mean ? Number(data.group2Mean) : undefined,
         pooledSD: data.pooledSD ? Number(data.pooledSD) : undefined,
@@ -503,7 +503,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -523,7 +523,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -543,7 +543,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -563,7 +563,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -596,7 +596,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -616,7 +616,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -638,7 +638,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -671,7 +671,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -691,7 +691,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }
@@ -711,7 +711,7 @@ export default function TTestPage() {
                               onChange={(e) =>
                                 field.onChange(
                                   e.target.value === ''
-                                    ? ''
+                                    ? undefined
                                     : parseFloat(e.target.value)
                                 )
                               }

--- a/app/(calc)/sample-size/t-test/page.tsx
+++ b/app/(calc)/sample-size/t-test/page.tsx
@@ -51,8 +51,8 @@ export default function TTestPage() {
     resolver: zodResolver(FormSchema),
     defaultValues: {
       // Common
-      alpha: '5', // 5% alpha level
-      power: '80', // 80% power
+      alpha: 5, // 5% alpha level
+      power: 80, // 80% power
       dropoutRate: 10,
 
       // Independent
@@ -496,7 +496,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Group 1 Mean</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -505,7 +516,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Group 2 Mean</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -514,7 +536,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Pooled Standard Deviation</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -523,7 +556,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Allocation Ratio (Group 1:Group 2)</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.1" {...field} />
+                            <Input
+                              type="number"
+                              step="0.1"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -545,7 +589,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Expected Mean Difference</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -554,7 +609,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Standard Deviation of Differences</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -563,7 +629,20 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Correlation between Pairs</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" min="0" max="1" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              min="0"
+                              max="1"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -585,7 +664,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Expected Sample Mean</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -594,7 +684,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Population Mean (H₀)</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -603,7 +704,18 @@ export default function TTestPage() {
                         <FormItem>
                           <FormLabel>Population Standard Deviation</FormLabel>
                           <FormControl>
-                            <Input type="number" step="0.01" {...field} />
+                            <Input
+                              type="number"
+                              step="0.01"
+                              {...field}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? ''
+                                    : parseFloat(e.target.value)
+                                )
+                              }
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/components/sample-size/CaseControlForm.tsx
+++ b/components/sample-size/CaseControlForm.tsx
@@ -47,8 +47,8 @@ export function CaseControlForm({ onResultsChange }: CaseControlFormProps) {
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      alpha: '5',
-      power: '80',
+      alpha: 5,
+      power: 80,
       ratio: 1,
       p0: 0.2, // 20% exposure in controls (realistic for case-control studies)
       p1: 0.4, // 40% exposure in cases (detectable odds ratio ~2.67)

--- a/components/sample-size/CaseControlForm.tsx
+++ b/components/sample-size/CaseControlForm.tsx
@@ -28,8 +28,8 @@ import {
 import { Calculator, AlertCircle, FileUp, Users } from 'lucide-react';
 
 const formSchema = z.object({
-  alpha: z.string().min(1, "Alpha level is required"),
-  power: z.string().min(1, "Power is required"),
+  alpha: z.number().min(1, "Alpha level is required"),
+  power: z.number().min(1, "Power is required"),
   ratio: z.number().min(0.1, "Ratio must be at least 0.1").max(10, "Ratio must be at most 10"),
   p0: z.number().min(0.001, "Control exposure rate must be at least 0.1%").max(0.999, "Control exposure rate must be less than 99.9%"),
   p1: z.number().min(0.001, "Case exposure rate must be at least 0.1%").max(0.999, "Case exposure rate must be less than 99.9%"),
@@ -58,8 +58,8 @@ export function CaseControlForm({ onResultsChange }: CaseControlFormProps) {
   const onSubmit = useCallback((values: FormData) => {
     try {
       setError(null);
-      const alpha = parseFloat(values.alpha) / 100;
-      const power = parseFloat(values.power) / 100;
+      const alpha = values.alpha / 100;
+      const power = values.power / 100;
       const { ratio, p0, p1 } = values;
 
     const sampleSize = calculateCaseControlSampleSize(

--- a/components/sample-size/CohortForm.tsx
+++ b/components/sample-size/CohortForm.tsx
@@ -47,8 +47,8 @@ export function CohortForm({ onResultsChange }: CohortFormProps) {
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      alpha: '5',
-      power: '80',
+      alpha: 5,
+      power: 80,
       ratio: 1,
       p1: 0.25, // 25% disease rate in exposed (meaningful relative risk)
       p2: 0.10, // 10% disease rate in unexposed (baseline rate)

--- a/components/sample-size/CohortForm.tsx
+++ b/components/sample-size/CohortForm.tsx
@@ -28,8 +28,8 @@ import {
 import { Calculator, AlertCircle, FileUp, TrendingUp } from 'lucide-react';
 
 const formSchema = z.object({
-  alpha: z.string().min(1, "Alpha level is required"),
-  power: z.string().min(1, "Power is required"),
+  alpha: z.number().min(1, "Alpha level is required"),
+  power: z.number().min(1, "Power is required"),
   ratio: z.number().min(0.1, "Ratio must be at least 0.1").max(10, "Ratio must be at most 10"),
   p1: z.number().min(0.001, "Disease rate in exposed must be at least 0.1%").max(0.999, "Disease rate in exposed must be less than 99.9%"),
   p2: z.number().min(0.001, "Disease rate in unexposed must be at least 0.1%").max(0.999, "Disease rate in unexposed must be less than 99.9%"),
@@ -58,8 +58,8 @@ export function CohortForm({ onResultsChange }: CohortFormProps) {
   const onSubmit = useCallback((values: FormData) => {
     try {
       setError(null);
-      const alpha = parseFloat(values.alpha) / 100;
-      const power = parseFloat(values.power) / 100;
+      const alpha = values.alpha / 100;
+      const power = values.power / 100;
       const { ratio, p1, p2 } = values;
 
     const sampleSize = calculateCohortSampleSize(


### PR DESCRIPTION
## Summary
- use numeric defaults for alpha and power values
- convert number inputs into numeric values for T-Test and Diagnostic calculators

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884e53989bc832ba90effb9eeb1cd70