### PR TITLE
Revamp theme to bright orange dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,29 +4,29 @@
 
 @layer base {
   :root {
-    /* Base colors - Light theme using correct Karmastat colors */
-    --background: 210 20% 98%; /* Light gray-blue background */
-    --foreground: 210 20% 15%; /* Dark text */
+    /* Base colors - Light theme using new vibrant orange palette */
+    --background: 34 100% 97%; /* very light orange tint */
+    --foreground: 24 90% 10%; /* dark brown text */
     --card: 210 20% 100%; /* Pure white cards */
     --card-foreground: 210 20% 15%; /* Dark text */
     --popover: 210 20% 100%; /* White popover */
     --popover-foreground: 210 20% 15%; /* Dark text */
 
-    /* Primary colors - Karmastat primary blue #146C94 */
-    --primary: 207 75% 33%; /* #146C94 - Karmastat primary blue */
-    --primary-foreground: 210 20% 98%; /* Light text on blue */
+    /* Primary colors - bright sunburst orange */
+    --primary: 32 100% 50%; /* vivid orange */
+    --primary-foreground: 0 0% 100%; /* white text */
 
-    /* Secondary colors - Karmastat secondary blue #19A7CE */
-    --secondary: 195 76% 45%; /* #19A7CE - Karmastat secondary blue */
-    --secondary-foreground: 210 20% 15%; /* Dark text on light blue */
+    /* Secondary colors - complementary golden yellow */
+    --secondary: 40 100% 55%;
+    --secondary-foreground: 24 90% 10%;
 
     /* Muted colors - Neutral grays */
     --muted: 210 20% 96%; /* Light gray background */
     --muted-foreground: 210 10% 45%; /* Medium gray text */
 
-    /* Accent colors - Karmastat accent #F8FDCF */
-    --accent: 60 67% 90%; /* #F8FDCF - Karmastat accent cream */
-    --accent-foreground: 210 20% 15%; /* Dark text on cream */
+    /* Accent colors */
+    --accent: 45 100% 85%; /* soft yellow */
+    --accent-foreground: 24 90% 10%;
 
     /* Semantic colors */
     --success: 122 39% 49%; /* Green */
@@ -45,53 +45,53 @@
     /* Border and input */
     --border: 210 20% 90%; /* Light gray borders */
     --input: 210 20% 90%; /* Light gray input borders */
-    --ring: 207 75% 33%; /* Primary blue focus ring */
+    --ring: 32 100% 50%; /* Orange focus ring */
 
     /* Radius */
     --radius: 0.75rem;
 
-    /* Chart colors - Karmastat blue palette */
-    --chart-1: 207 75% 33%; /* Primary blue */
-    --chart-2: 195 76% 45%; /* Secondary blue */
-    --chart-3: 200 80% 55%; /* Light blue */
-    --chart-4: 215 70% 40%; /* Dark blue */
-    --chart-5: 185 85% 60%; /* Cyan blue */
+    /* Chart colors - warm oranges */
+    --chart-1: 32 100% 50%;
+    --chart-2: 40 100% 55%;
+    --chart-3: 45 100% 60%;
+    --chart-4: 24 90% 45%;
+    --chart-5: 15 90% 40%;
 
     /* Sidebar colors */
     --sidebar: 210 20% 100%; /* White sidebar */
     --sidebar-foreground: 210 20% 15%; /* Dark text */
-    --sidebar-primary: 207 75% 33%; /* Primary blue */
-    --sidebar-primary-foreground: 210 20% 98%; /* Light text on blue */
-    --sidebar-accent: 210 20% 96%; /* Light gray accent */
-    --sidebar-accent-foreground: 210 20% 15%; /* Dark text */
-    --sidebar-border: 210 20% 90%; /* Light gray border */
-    --sidebar-ring: 207 75% 33%; /* Primary blue focus ring */
+    --sidebar-primary: 32 100% 50%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 34 100% 97%;
+    --sidebar-accent-foreground: 24 90% 10%;
+    --sidebar-border: 34 100% 90%;
+    --sidebar-ring: 32 100% 50%;
   }
 
   .dark {
-    /* Base colors - Dark theme with Karmastat blues */
-    --background: 210 20% 8%; /* Dark background */
-    --foreground: 210 20% 95%; /* Light text */
-    --card: 210 20% 12%; /* Dark card background */
-    --card-foreground: 210 20% 95%; /* Light text */
-    --popover: 210 20% 12%; /* Dark popover */
-    --popover-foreground: 210 20% 95%; /* Light text */
+    /* Base colors - Dark orange theme */
+    --background: 24 90% 8%;
+    --foreground: 34 100% 95%;
+    --card: 24 90% 10%;
+    --card-foreground: 34 100% 95%;
+    --popover: 24 90% 10%;
+    --popover-foreground: 34 100% 95%;
 
-    /* Primary colors - Lighter blue for dark mode */
-    --primary: 195 76% 65%; /* Lighter blue for dark mode */
-    --primary-foreground: 210 20% 8%; /* Dark text on blue */
+    /* Primary colors - bright orange for dark mode */
+    --primary: 32 100% 60%;
+    --primary-foreground: 24 90% 10%;
 
-    /* Secondary colors - Lighter secondary for dark mode */
-    --secondary: 185 85% 70%; /* Lighter secondary blue */
-    --secondary-foreground: 210 20% 8%; /* Dark text */
+    /* Secondary colors - golden accent */
+    --secondary: 40 100% 60%;
+    --secondary-foreground: 24 90% 10%;
 
     /* Muted colors */
     --muted: 210 20% 20%; /* Dark muted background */
     --muted-foreground: 210 20% 70%; /* Light muted text */
 
     /* Accent colors */
-    --accent: 210 20% 25%; /* Dark accent background */
-    --accent-foreground: 210 20% 95%; /* Light text */
+    --accent: 35 100% 25%;
+    --accent-foreground: 34 100% 95%;
 
     /* Semantic colors - Dark theme variants */
     --success: 122 39% 69%; /* Lighter green */
@@ -110,24 +110,24 @@
     /* Border and input */
     --border: 210 20% 25%; /* Dark borders */
     --input: 210 20% 25%; /* Dark input borders */
-    --ring: 195 76% 65%; /* Light blue focus ring */
+    --ring: 32 100% 60%;
 
     /* Chart colors - Dark theme */
-    --chart-1: 195 76% 65%; /* Lighter primary for dark */
-    --chart-2: 185 85% 70%; /* Lighter secondary for dark */
-    --chart-3: 200 80% 75%; /* Light blue for dark */
-    --chart-4: 215 70% 60%; /* Dark blue for dark */
-    --chart-5: 185 85% 80%; /* Cyan blue for dark */
+    --chart-1: 32 100% 60%;
+    --chart-2: 40 100% 60%;
+    --chart-3: 45 100% 65%;
+    --chart-4: 24 90% 50%;
+    --chart-5: 15 90% 45%;
 
     /* Sidebar colors - Dark theme */
-    --sidebar: 210 20% 12%; /* Dark sidebar */
-    --sidebar-foreground: 210 20% 95%; /* Light text */
-    --sidebar-primary: 195 76% 65%; /* Lighter blue */
-    --sidebar-primary-foreground: 210 20% 8%; /* Dark text */
-    --sidebar-accent: 210 20% 25%; /* Dark accent */
-    --sidebar-accent-foreground: 210 20% 95%; /* Light text */
-    --sidebar-border: 210 20% 25%; /* Dark border */
-    --sidebar-ring: 195 76% 65%; /* Light blue focus ring */
+    --sidebar: 24 90% 10%;
+    --sidebar-foreground: 34 100% 95%;
+    --sidebar-primary: 32 100% 60%;
+    --sidebar-primary-foreground: 24 90% 10%;
+    --sidebar-accent: 35 100% 25%;
+    --sidebar-accent-foreground: 34 100% 95%;
+    --sidebar-border: 24 90% 15%;
+    --sidebar-ring: 32 100% 60%;
   }
 
   /* Base element styles */

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,9 +4,9 @@
 
 @layer base {
   :root {
-    /* Base colors - Light theme using new vibrant orange palette */
-    --background: 34 100% 97%; /* very light orange tint */
-    --foreground: 24 90% 10%; /* dark brown text */
+    /* Base colors - Light theme */
+    --background: 0 0% 100%; /* white background */
+    --foreground: 0 0% 0%; /* black text */
     --card: 210 20% 100%; /* Pure white cards */
     --card-foreground: 210 20% 15%; /* Dark text */
     --popover: 210 20% 100%; /* White popover */
@@ -69,17 +69,17 @@
   }
 
   .dark {
-    /* Base colors - Dark orange theme */
-    --background: 24 90% 8%;
-    --foreground: 34 100% 95%;
+    /* Base colors - Dark theme */
+    --background: 0 0% 0%; /* black background */
+    --foreground: 0 0% 100%; /* white text */
     --card: 24 90% 10%;
     --card-foreground: 34 100% 95%;
     --popover: 24 90% 10%;
     --popover-foreground: 34 100% 95%;
 
-    /* Primary colors - bright orange for dark mode */
-    --primary: 32 100% 60%;
-    --primary-foreground: 24 90% 10%;
+    /* Primary colors - brighter orange for dark mode */
+    --primary: 32 100% 65%;
+    --primary-foreground: 0 0% 0%;
 
     /* Secondary colors - golden accent */
     --secondary: 40 100% 60%;
@@ -294,25 +294,25 @@
 
   /* Gradient animations with Karmastat colors */
   .gradient-animation {
-    background: linear-gradient(-45deg, hsl(207, 75%, 33%), hsl(195, 76%, 45%), hsl(200, 80%, 55%), hsl(185, 85%, 60%));
+    background: linear-gradient(-45deg, hsl(var(--primary)), hsl(var(--secondary)), hsl(var(--accent)), hsl(var(--secondary)));
     background-size: 400% 400%;
     animation: gradientShift 8s ease-in-out infinite;
   }
 
   .mesh-gradient {
-    background: radial-gradient(circle at 20% 50%, hsl(207, 75%, 33%) 0%, transparent 70%),
-                radial-gradient(circle at 80% 20%, hsl(195, 76%, 45%) 0%, transparent 70%),
-                radial-gradient(circle at 40% 80%, hsl(185, 85%, 60%) 0%, transparent 70%);
+    background: radial-gradient(circle at 20% 50%, hsl(var(--primary)) 0%, transparent 70%),
+                radial-gradient(circle at 80% 20%, hsl(var(--secondary)) 0%, transparent 70%),
+                radial-gradient(circle at 40% 80%, hsl(var(--accent)) 0%, transparent 70%);
   }
 
   .rainbow-gradient {
     background: linear-gradient(
       90deg,
-      hsl(207, 75%, 33%),
-      hsl(195, 76%, 45%),
-      hsl(200, 80%, 55%),
-      hsl(185, 85%, 60%),
-      hsl(207, 75%, 33%)
+      hsl(var(--primary)),
+      hsl(var(--secondary)),
+      hsl(var(--accent)),
+      hsl(var(--secondary)),
+      hsl(var(--primary))
     );
     background-size: 200% 200%;
     animation: rainbowShift 6s ease-in-out infinite;
@@ -320,25 +320,25 @@
 
   /* Glow effects with Karmastat primary */
   .glow-primary {
-    box-shadow: 0 0 20px hsl(207, 75%, 33%, 0.3);
+    box-shadow: 0 0 20px hsl(var(--primary) / 0.3);
     transition: box-shadow 0.3s ease;
   }
 
   .glow-secondary {
-    box-shadow: 0 0 20px hsl(195, 76%, 45%, 0.3);
+    box-shadow: 0 0 20px hsl(var(--secondary) / 0.3);
     transition: box-shadow 0.3s ease;
   }
 
   .glow-hover:hover {
-    box-shadow: 0 0 30px hsl(207, 75%, 33%, 0.4);
+    box-shadow: 0 0 30px hsl(var(--primary) / 0.4);
   }
 
   .glow-secondary:hover {
-    box-shadow: 0 0 30px hsl(195, 76%, 45%, 0.4);
+    box-shadow: 0 0 30px hsl(var(--secondary) / 0.4);
   }
 
   .text-glow {
-    text-shadow: 0 0 10px hsl(207, 75%, 33%, 0.5);
+    text-shadow: 0 0 10px hsl(var(--primary) / 0.5);
   }
 
   /* Button styles with Karmastat theme */
@@ -373,7 +373,7 @@
 
   /* Text gradients with Karmastat colors */
   .text-gradient {
-    background: linear-gradient(135deg, hsl(207, 75%, 33%), hsl(195, 76%, 45%));
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--secondary)));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,7 +35,8 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased" style={{ margin: 0, padding: 0 }} suppressHydrationWarning>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        {/* Default to dark theme for a high contrast look */}
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <Suspense fallback={null}>
             <LayoutWrapper>{children}</LayoutWrapper>
           </Suspense>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,8 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-12 w-full min-w-0 rounded-md border bg-transparent px-4 py-2 text-lg font-semibold shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-base file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:glow-primary",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/components/ui/modern-results-display.tsx
+++ b/components/ui/modern-results-display.tsx
@@ -211,7 +211,7 @@ export function ModernResultsDisplay({
             {getTrendIcon(item.trend)}
           </div>
           <div className="space-y-2">
-            <div className="text-2xl font-bold">
+            <div className="text-3xl font-extrabold text-glow">
               {formatNumber(item.value, item.format)}
             </div>
             {item.description && (
@@ -230,7 +230,7 @@ export function ModernResultsDisplay({
     <div className={cn("space-y-6", className)}>
       {title && (
         <div className="space-y-2">
-                  <h2 className="text-3xl font-bold text-foreground">{title}</h2>
+                  <h2 className="text-4xl font-extrabold text-foreground text-glow">{title}</h2>
         <p className="text-lg text-muted-foreground">
             Statistical analysis results
           </p>

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-20 w-full rounded-md border bg-transparent px-4 py-3 text-lg font-semibold shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:glow-primary disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -313,7 +313,7 @@ export const lightTheme = {
   destructiveForeground: '#FFFFFF', // white text
   border: '#E2E8F0', // border-color from legacy
   input: '#E2E8F0', // border-color from legacy
-  ring: '#FF9500', // primary focus ring
+  ring: '#FEAB4C', // primary focus ring
   success: '#38A169', // success from legacy
   warning: '#D69E2E', // warning from legacy
   error: '#E53E3E', // danger from legacy
@@ -322,14 +322,14 @@ export const lightTheme = {
 
 // Dark theme configuration - From legacy dark theme
 export const darkTheme = {
-  background: '#1A202C', // bg-primary from legacy dark
-  foreground: '#F7FAFC', // text-primary from legacy dark
+  background: '#000000', // black background for high contrast
+  foreground: '#FFFFFF', // white text
   card: '#2D3748', // bg-card from legacy dark
   cardForeground: '#F7FAFC', // text-primary from legacy dark
   popover: '#2D3748', // bg-secondary from legacy dark
   popoverForeground: '#F7FAFC', // text-primary from legacy dark
-  primary: '#FF9500', // bright orange
-  primaryForeground: '#1A202C', // dark text on orange
+  primary: '#FEAB4C', // brighter orange for dark mode
+  primaryForeground: '#000000', // dark text on orange
   secondary: '#FFA900', // golden secondary
   secondaryForeground: '#1A202C', // dark text
   muted: '#2D3748', // bg-secondary from legacy dark
@@ -340,7 +340,7 @@ export const darkTheme = {
   destructiveForeground: '#F7FAFC', // light text
   border: '#4A5568', // border-color from legacy dark
   input: '#4A5568', // border-color from legacy dark
-  ring: '#FF9500', // primary focus ring
+  ring: '#FEAB4C', // primary focus ring
   success: '#38A169', // success from legacy
   warning: '#D69E2E', // warning from legacy
   error: '#E53E3E', // danger from legacy

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -2,43 +2,43 @@
 // Based on legacy karmastat_comparative_fixed.html and ICMR-NIN 2020 Guidelines
 
 export const karmaTheme = {
-  // Core color palette - KARMASTAT Academic Orange-Blue theme
+  // Core color palette - vibrant "sun rays" orange theme
   colors: {
-    // Primary colors - Academic orange spectrum
+    // Primary colors - warm and bright oranges
     primary: {
-      50: '#fff7ed',
-      100: '#ffedd5',
-      200: '#fed7aa',
-      300: '#fdba74',
-      400: '#FFB570', // primary-light from legacy
-      500: '#FF8C42', // Brand primary - vibrant orange (legacy)
-      600: '#E67A2F', // primary-dark from legacy
-      700: '#c2410c',
-      800: '#9a3412',
-      900: '#7c2d12',
-      DEFAULT: '#FF8C42',
+      50: '#FFF7ED',
+      100: '#FFE8D6',
+      200: '#FFD2AD',
+      300: '#FFBB85',
+      400: '#FFA45C',
+      500: '#FF9500', // vivid orange
+      600: '#DB7700',
+      700: '#BB5F00',
+      800: '#9B4500',
+      900: '#7B3200',
+      DEFAULT: '#FF9500',
     },
 
-    // Secondary colors - Academic blue spectrum
+    // Secondary colors - golden yellows complementing the orange
     secondary: {
-      50: '#eff6ff',
-      100: '#dbeafe',
-      200: '#bfdbfe',
-      300: '#93c5fd',
-      400: '#60a5fa',
-      500: '#2C5282', // Brand secondary - academic blue (legacy)
-      600: '#1e40af',
-      700: '#1d4ed8',
-      800: '#1e3a8a',
-      900: '#1e3a8a',
-      DEFAULT: '#2C5282',
+      50: '#FFFBEB',
+      100: '#FEF3C7',
+      200: '#FDE68A',
+      300: '#FCD34D',
+      400: '#FBBF24',
+      500: '#FFA900',
+      600: '#D48806',
+      700: '#B27005',
+      800: '#8F5904',
+      900: '#6C4303',
+      DEFAULT: '#FFA900',
     },
 
     // Accent color - From legacy
     accent: {
-      light: '#F8FDCF', // accent from legacy
-      neutral: '#fdf4e6',
-      DEFAULT: '#F6AD55', // accent from legacy
+      light: '#FFF7D1',
+      neutral: '#FFE9B0',
+      DEFAULT: '#FFD166', // vibrant accent yellow
     },
 
     // Additional legacy colors
@@ -208,20 +208,20 @@ export const karmaTheme = {
 
   // Gradients - From legacy academic design
   gradients: {
-    primary: 'linear-gradient(135deg, #FF8C42, #F6AD55, #FFB570)', // gradient-primary from legacy
-    secondary: 'linear-gradient(135deg, #2C5282, #3182CE, #4299E1)', // gradient-secondary from legacy
-    bg: 'linear-gradient(135deg, #FFF5F0, #FEEBC8, #FED7AA)', // gradient-bg from legacy
+    primary: 'linear-gradient(135deg, #FF9500, #FFA45C, #FFD166)', // bright orange gradient
+    secondary: 'linear-gradient(135deg, #FFA900, #FFD166, #FFE9B0)', // golden secondary gradient
+    bg: 'linear-gradient(135deg, #2B1A08, #4B2A0A, #000)', // dark background gradient
     card: 'linear-gradient(145deg, #FFFFFF, #F7FAFC)', // gradient-card from legacy
     magic: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', // gradient-magic from legacy
     analytical: 'linear-gradient(135deg, #11998e 0%, #38ef7d 100%)', // gradient-analytical from legacy
     formula: 'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)', // gradient-formula from legacy
-    accent: 'linear-gradient(135deg, #F8FDCF, #F6AD55)', // Accent gradient
+    accent: 'linear-gradient(135deg, #FFE9B0, #FFD166)', // Accent gradient
     success: 'linear-gradient(135deg, #38A169, #68D391)',
     warning: 'linear-gradient(135deg, #D69E2E, #F6E05E)',
     error: 'linear-gradient(135deg, #E53E3E, #FC8181)',
-    hero: 'linear-gradient(135deg, #FF8C42 0%, #2C5282 50%, #F8FDCF 100%)', // Orange to blue to cream
-    sunset: 'linear-gradient(135deg, #FFB570 0%, #FF8C42 25%, #2C5282 75%, #3182CE 100%)', // Full spectrum
-    warm: 'linear-gradient(135deg, #FFF5F0, #F8FDCF)', // Soft warm gradient
+    hero: 'linear-gradient(135deg, #FF9500 0%, #FFA900 50%, #FFD166 100%)', // orange sunrise
+    sunset: 'linear-gradient(135deg, #FFD166 0%, #FF9500 50%, #2B1A08 100%)', // warm sunset
+    warm: 'linear-gradient(135deg, #4B2A0A, #2B1A08)', // Soft dark gradient
   },
 
   // Transitions - From legacy
@@ -301,19 +301,19 @@ export const lightTheme = {
   cardForeground: '#2D3748', // text-primary from legacy
   popover: '#FFFFFF', // bg-primary from legacy
   popoverForeground: '#2D3748', // text-primary from legacy
-  primary: '#FF8C42', // primary from legacy
+  primary: '#FF9500', // bright orange primary
   primaryForeground: '#FFFFFF', // white text on orange
-  secondary: '#2C5282', // secondary from legacy
-  secondaryForeground: '#FFFFFF', // white text on blue
+  secondary: '#FFA900', // golden secondary
+  secondaryForeground: '#1A202C', // dark text on yellow
   muted: '#F7FAFC', // bg-secondary from legacy
   mutedForeground: '#718096', // text-muted from legacy
-  accent: '#F6AD55', // accent from legacy
+  accent: '#FFD166', // yellow accent
   accentForeground: '#2D3748', // text-primary from legacy
   destructive: '#E53E3E', // danger from legacy
   destructiveForeground: '#FFFFFF', // white text
   border: '#E2E8F0', // border-color from legacy
   input: '#E2E8F0', // border-color from legacy
-  ring: '#FF8C42', // primary focus ring
+  ring: '#FF9500', // primary focus ring
   success: '#38A169', // success from legacy
   warning: '#D69E2E', // warning from legacy
   error: '#E53E3E', // danger from legacy
@@ -328,19 +328,19 @@ export const darkTheme = {
   cardForeground: '#F7FAFC', // text-primary from legacy dark
   popover: '#2D3748', // bg-secondary from legacy dark
   popoverForeground: '#F7FAFC', // text-primary from legacy dark
-  primary: '#FF8C42', // primary from legacy (same in dark)
+  primary: '#FF9500', // bright orange
   primaryForeground: '#1A202C', // dark text on orange
-  secondary: '#2C5282', // secondary from legacy (same in dark)
-  secondaryForeground: '#F7FAFC', // light text on blue
+  secondary: '#FFA900', // golden secondary
+  secondaryForeground: '#1A202C', // dark text
   muted: '#2D3748', // bg-secondary from legacy dark
   mutedForeground: '#A0AEC0', // text-muted from legacy dark
-  accent: '#F6AD55', // accent from legacy (same in dark)
-  accentForeground: '#1A202C', // dark text on accent
+  accent: '#FFD166',
+  accentForeground: '#1A202C',
   destructive: '#E53E3E', // danger from legacy
   destructiveForeground: '#F7FAFC', // light text
   border: '#4A5568', // border-color from legacy dark
   input: '#4A5568', // border-color from legacy dark
-  ring: '#FF8C42', // primary focus ring
+  ring: '#FF9500', // primary focus ring
   success: '#38A169', // success from legacy
   warning: '#D69E2E', // warning from legacy
   error: '#E53E3E', // danger from legacy


### PR DESCRIPTION
## Summary
- switch default theme to dark
- update design tokens to vibrant orange palette
- highlight inputs and outputs with bigger fonts
- modernize results display with glowing orange text

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884e6ed02c8832bbd56a7b38f8bf0c0