### PR TITLE
feat: add unified tool backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Karmastats is built with some seriously cool tech:
 - **Schema Validation:** Zod - Keep your data clean and reliable.
 - **Deployment:** Vercel - Bringing Karmastats to the world! (as implied by @vercel/analytics and @vercel/speed-insights)
 
+## 🔧 Backend Architecture
+
+All statistical calculators share a unified backend interface. Calculation logic lives in `lib/tools`, and each tool—from regression and sample size to survival analysis and study detection—is accessible through the API route `/api/tools/[tool]`. Handlers are lazy-loaded on demand for better performance, and client components invoke them via `runTool` from `lib/tools/client.ts`.
+
 ## 🚀 Getting Started 🚦
 
 Ready to jump in? Here’s how to get Karmastats running on your local machine:

--- a/app/api/tools/[tool]/route.ts
+++ b/app/api/tools/[tool]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getTool } from '@/lib/tools';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { tool: string } }
+) {
+  const handler = await getTool(params.tool);
+  if (!handler) {
+    return NextResponse.json({ error: 'Unknown tool' }, { status: 404 });
+  }
+
+  const body = await req.json();
+  const result = await handler(body);
+  return NextResponse.json(result);
+}

--- a/components/regression/LinearRegressionForm.tsx
+++ b/components/regression/LinearRegressionForm.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { linearRegression, LinearRegressionResult } from "@/lib/regression";
+import type { LinearRegressionResult } from "@/lib/regression";
+import { runTool } from "@/lib/tools/client";
 import { Button, NeuomorphicButton } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -138,7 +139,7 @@ export function LinearRegressionForm({ onResultsChange }: LinearRegressionFormPr
     onResultsChange?.(null);
   };
 
-  const onSubmit = (data: z.infer<typeof FormSchema>) => {
+  const onSubmit = async (data: z.infer<typeof FormSchema>) => {
     try {
       setError(null);
       setResult(null);
@@ -162,7 +163,10 @@ export function LinearRegressionForm({ onResultsChange }: LinearRegressionFormPr
         return;
       }
 
-      const regressionResult = linearRegression(parsedX, parsedY);
+      const regressionResult = await runTool<LinearRegressionResult | { error: string }>('linear-regression', {
+        xValues: parsedX,
+        yValues: parsedY
+      });
 
       if ("error" in regressionResult) {
         setError(regressionResult.error);

--- a/components/regression/LinearRegressionTab.tsx
+++ b/components/regression/LinearRegressionTab.tsx
@@ -6,7 +6,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { linearRegression, LinearRegressionResult } from "@/lib/regression";
+import type { LinearRegressionResult } from "@/lib/regression";
+import { runTool } from "@/lib/tools/client";
 import dynamic from "next/dynamic";
 
 // Dynamically import Chart.js to prevent SSR issues
@@ -55,11 +56,14 @@ export function LinearRegressionTab() {
   const [error, setError] = useState<string | null>(null);
   const [showResidual, setShowResidual] = useState(false);
 
-  const handleCalculate = () => {
+  const handleCalculate = async () => {
     const xVals = parseInput(xInput);
     const yVals = parseInput(yInput);
-    const res = linearRegression(xVals, yVals);
-    if ("error" in res) {
+    const res = await runTool<LinearRegressionResult | { error: string }>('linear-regression', {
+      xValues: xVals,
+      yValues: yVals
+    });
+    if ('error' in res) {
       setError(res.error);
       setResult(null);
     } else {

--- a/components/regression/LogisticRegressionForm.tsx
+++ b/components/regression/LogisticRegressionForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from "react";
-import { logisticRegression, LogisticRegressionResult } from "@/lib/regression";
+import type { LogisticRegressionResult } from "@/lib/regression";
+import { runTool } from "@/lib/tools/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -116,16 +117,16 @@ export function LogisticRegressionForm({ onResultsChange }: LogisticRegressionFo
         onResultsChange?.(null);
     };
 
-    const handleCalculate = () => {
+    const handleCalculate = async () => {
         setError(null);
         setResult(null);
         onResultsChange?.(null);
 
         try {
             const { y, X } = parseMatrixInput(dataMatrix);
-            const regressionResult = logisticRegression(y, X);
+            const regressionResult = await runTool<LogisticRegressionResult | { error: string }>('logistic-regression', { y, X });
 
-            if ("error" in regressionResult) {
+            if ('error' in regressionResult) {
                 setError(regressionResult.error);
             } else {
                 setResult(regressionResult);

--- a/components/regression/MultipleRegressionForm.tsx
+++ b/components/regression/MultipleRegressionForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from "react";
-import { multipleRegression, MultipleRegressionResult } from "@/lib/regression";
+import type { MultipleRegressionResult } from "@/lib/regression";
+import { runTool } from "@/lib/tools/client";
 import { Button, NeuomorphicButton } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -137,16 +138,16 @@ export function MultipleRegressionForm({ onResultsChange }: MultipleRegressionFo
         onResultsChange?.(null);
     };
 
-    const handleCalculate = () => {
+    const handleCalculate = async () => {
         setError(null);
         setResult(null);
         onResultsChange?.(null);
 
         try {
             const { y, X } = parseMatrixInput(dataMatrix);
-            const regressionResult = multipleRegression(y, X);
+            const regressionResult = await runTool<MultipleRegressionResult | { error: string }>('multiple-regression', { y, X });
 
-            if ("error" in regressionResult) {
+            if ('error' in regressionResult) {
                 setError(regressionResult.error);
             } else {
                 setResult(regressionResult);

--- a/components/regression/MultipleRegressionTab.tsx
+++ b/components/regression/MultipleRegressionTab.tsx
@@ -6,7 +6,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { multipleRegression, MultipleRegressionResult } from "@/lib/regression";
+import type { MultipleRegressionResult } from "@/lib/regression";
+import { runTool } from "@/lib/tools/client";
 import dynamic from "next/dynamic";
 
 // Dynamically import Chart.js to prevent SSR issues
@@ -69,7 +70,7 @@ export function MultipleRegressionTab() {
   const [error, setError] = useState<string | null>(null);
   const [showChart, setShowChart] = useState<'predicted' | 'residuals'>("predicted");
 
-  const handleCalculate = () => {
+  const handleCalculate = async () => {
     const yVals = parseVectorInput(yInput);
     const xRows = parseColumnInput(xInput);
     // Transpose to get columns as variables
@@ -90,8 +91,8 @@ export function MultipleRegressionTab() {
       setResult(null);
       return;
     }
-    const res = multipleRegression(yVals, X);
-    if ("error" in res) {
+    const res = await runTool<MultipleRegressionResult | { error: string }>('multiple-regression', { y: yVals, X });
+    if ('error' in res) {
       setError(res.error);
       setResult(null);
     } else {

--- a/components/regression/PolynomialRegressionForm.tsx
+++ b/components/regression/PolynomialRegressionForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from "react";
-import { polynomialRegression, MultipleRegressionResult } from "@/lib/regression";
+import type { MultipleRegressionResult } from "@/lib/regression";
+import { runTool } from "@/lib/tools/client";
 import { Button, NeuomorphicButton } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -180,7 +181,7 @@ export function PolynomialRegressionForm({ onResultsChange }: PolynomialRegressi
         }
     };
 
-    const handleCalculate = () => {
+    const handleCalculate = async () => {
         setError(null);
         setResult(null);
         onResultsChange?.(null);
@@ -194,9 +195,13 @@ export function PolynomialRegressionForm({ onResultsChange }: PolynomialRegressi
             return;
         }
 
-        const regressionResult = polynomialRegression(parsedX, parsedY, parsedDegree);
+        const regressionResult = await runTool<MultipleRegressionResult | { error: string }>('polynomial-regression', {
+            xValues: parsedX,
+            yValues: parsedY,
+            degree: parsedDegree
+        });
 
-        if ("error" in regressionResult) {
+        if ('error' in regressionResult) {
             setError(regressionResult.error);
         } else {
             setResult(regressionResult);

--- a/components/sample-size/CoxRegressionForm.tsx
+++ b/components/sample-size/CoxRegressionForm.tsx
@@ -3,7 +3,8 @@
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { calculateCox, CoxParams } from '@/lib/survivalAnalysis';
+import { CoxParams, type SurvivalAnalysisResults } from '@/lib/survivalAnalysis';
+import { runTool } from '@/lib/tools/client';
 import { NeuomorphicButton } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -37,8 +38,11 @@ export function CoxRegressionForm({ onResultsChange }: CoxRegressionFormProps) {
     },
   });
 
-  const onSubmit = (data: FormData) => {
-    const calculatedResult = calculateCox(data as CoxParams);
+  const onSubmit = async (data: FormData) => {
+    const calculatedResult = await runTool<SurvivalAnalysisResults>(
+      'cox-regression',
+      data as CoxParams
+    );
     onResultsChange?.(calculatedResult);
   };
 

--- a/components/sample-size/IndependentTTestForm.tsx
+++ b/components/sample-size/IndependentTTestForm.tsx
@@ -24,11 +24,11 @@ import {
 import { useState, useRef } from "react";
 import { jsPDF } from "jspdf";
 import {
-    calculateIndependentSampleSize,
     IndependentSampleSizeSchema,
     type IndependentSampleSizeInput,
     type IndependentSampleSizeOutput
 } from "@/lib/math/sample-size/tTest";
+import { runTool } from "@/lib/tools/client";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { AlertCircle, Target, Calculator, Users, TrendingUp } from "lucide-react";
@@ -59,8 +59,11 @@ export function IndependentTTestForm() {
     },
   });
 
-  function onSubmit(values: IndependentSampleSizeInput) {
-    const sampleSize = calculateIndependentSampleSize(values);
+  async function onSubmit(values: IndependentSampleSizeInput) {
+    const sampleSize = await runTool<IndependentSampleSizeOutput>(
+      'independent-ttest-sample-size',
+      values
+    );
     setResult(sampleSize);
   }
 

--- a/components/sample-size/LogRankForm.tsx
+++ b/components/sample-size/LogRankForm.tsx
@@ -3,7 +3,8 @@
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { calculateLogRank, LogRankParams } from '@/lib/survivalAnalysis';
+import { LogRankParams, type SurvivalAnalysisResults } from '@/lib/survivalAnalysis';
+import { runTool } from '@/lib/tools/client';
 import { NeuomorphicButton } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -41,8 +42,11 @@ export function LogRankForm({ onResultsChange }: LogRankFormProps) {
     },
   });
 
-  const onSubmit = (data: FormData) => {
-    const calculatedResult = calculateLogRank(data as LogRankParams);
+  const onSubmit = async (data: FormData) => {
+    const calculatedResult = await runTool<SurvivalAnalysisResults>(
+      'log-rank',
+      data as LogRankParams
+    );
     onResultsChange(calculatedResult);
     // Scroll to top to show results
   };

--- a/components/sample-size/OneArmSurvivalForm.tsx
+++ b/components/sample-size/OneArmSurvivalForm.tsx
@@ -9,7 +9,8 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { calculateOneArm, OneArmParams } from '@/lib/survivalAnalysis';
+import { OneArmParams, type SurvivalAnalysisResults } from '@/lib/survivalAnalysis';
+import { runTool } from '@/lib/tools/client';
 
 const OneArmSurvivalSchema = z.object({
   historicalMedianSurvival: z.number().min(0.1),
@@ -41,10 +42,13 @@ export function OneArmSurvivalForm({ onResultsChange }: OneArmSurvivalFormProps)
     },
   });
 
-  const onSubmit = (data: OneArmSurvivalInput) => {
+  const onSubmit = async (data: OneArmSurvivalInput) => {
     try {
       setError(null);
-      const result = calculateOneArm(data);
+      const result = await runTool<SurvivalAnalysisResults>(
+        'one-arm-survival',
+        data as OneArmParams
+      );
       onResultsChange(result);
       // Scroll to top to show results
     } catch (err: any) {

--- a/components/sample-size/StudyDetectorForm.tsx
+++ b/components/sample-size/StudyDetectorForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState } from 'react';
-import { analyzeStudy, StudyRecommendation } from "@/lib/studyDetector";
+import { StudyRecommendation } from "@/lib/studyDetector";
+import { runTool } from "@/lib/tools/client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
@@ -31,7 +32,10 @@ export function StudyDetectorForm({ onAnalysisComplete, setIsLoading, isLoading 
         try {
             // Simulate processing time for better UX
             await new Promise(resolve => setTimeout(resolve, 1500));
-            const recommendations = analyzeStudy(researchText);
+            const recommendations = await runTool<StudyRecommendation[]>(
+                'study-detector',
+                { text: researchText }
+            );
             onAnalysisComplete(recommendations);
         } catch (err: any) {
             setError(`Analysis failed: ${err.message}`);

--- a/lib/tools/client.ts
+++ b/lib/tools/client.ts
@@ -1,0 +1,11 @@
+export async function runTool<T>(name: string, data: any): Promise<T> {
+  const res = await fetch(`/api/tools/${name}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    throw new Error(`Tool request failed with status ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -1,0 +1,80 @@
+export type ToolHandler = (data: any) => any | Promise<any>;
+
+type ToolLoader = () => Promise<ToolHandler>;
+
+// Lazy-loaded tool registry to keep cold starts fast
+const loaders: Record<string, ToolLoader> = {
+  'linear-regression': async () => {
+    const { linearRegression } = await import('../regression');
+    return ({ xValues, yValues }: { xValues: number[]; yValues: number[] }) =>
+      linearRegression(xValues, yValues);
+  },
+  'multiple-regression': async () => {
+    const { multipleRegression } = await import('../regression');
+    return ({ y, X }: { y: number[]; X: number[][] }) =>
+      multipleRegression(y, X);
+  },
+  'polynomial-regression': async () => {
+    const { polynomialRegression } = await import('../regression');
+    return ({ xValues, yValues, degree }: { xValues: number[]; yValues: number[]; degree: number }) =>
+      polynomialRegression(xValues, yValues, degree);
+  },
+  'logistic-regression': async () => {
+    const { logisticRegression } = await import('../regression');
+    return ({ y, X, options }: { y: number[]; X: number[][]; options?: any }) =>
+      logisticRegression(y, X, options);
+  },
+  'case-control-sample-size': async () => {
+    const { calculateCaseControlSampleSize } = await import('../math/sample-size/comparativeStudy');
+    return ({ alpha, power, ratio, p0, p1 }: { alpha: number; power: number; ratio: number; p0: number; p1: number }) =>
+      calculateCaseControlSampleSize(alpha, power, ratio, p0, p1);
+  },
+  'cohort-sample-size': async () => {
+    const { calculateCohortSampleSize } = await import('../math/sample-size/comparativeStudy');
+    return ({ alpha, power, ratio, p1, p2 }: { alpha: number; power: number; ratio: number; p1: number; p2: number }) =>
+      calculateCohortSampleSize(alpha, power, ratio, p1, p2);
+  },
+  'independent-ttest-sample-size': async () => {
+    const { calculateIndependentSampleSize } = await import('../math/sample-size/tTest');
+    return (params: any) => calculateIndependentSampleSize(params);
+  },
+  'paired-ttest-sample-size': async () => {
+    const { calculatePairedSampleSize } = await import('../math/sample-size/tTest');
+    return (params: any) => calculatePairedSampleSize(params);
+  },
+  'one-sample-ttest-sample-size': async () => {
+    const { calculateOneSampleSampleSize } = await import('../math/sample-size/tTest');
+    return (params: any) => calculateOneSampleSampleSize(params);
+  },
+  'cox-regression': async () => {
+    const { calculateCox } = await import('../survivalAnalysis');
+    return (params: any) => calculateCox(params);
+  },
+  'log-rank': async () => {
+    const { calculateLogRank } = await import('../survivalAnalysis');
+    return (params: any) => calculateLogRank(params);
+  },
+  'one-arm-survival': async () => {
+    const { calculateOneArm } = await import('../survivalAnalysis');
+    return (params: any) => calculateOneArm(params);
+  },
+  'study-detector': async () => {
+    const { analyzeStudy } = await import('../studyDetector');
+    return ({ text }: { text: string }) => analyzeStudy(text);
+  }
+};
+
+const cache: Record<string, ToolHandler> = {};
+
+export async function getTool(name: string): Promise<ToolHandler | undefined> {
+  if (cache[name]) return cache[name];
+  const loader = loaders[name];
+  if (!loader) return undefined;
+  const handler = await loader();
+  cache[name] = handler;
+  return handler;
+}
+
+export function registerTool(name: string, loader: ToolLoader) {
+  loaders[name] = loader;
+}


### PR DESCRIPTION
## Summary
- expand lazy-loaded tool registry to handle sample size, survival analysis, and study detection calculators
- refactor statistical forms to call tools through unified `/api/tools/[tool]`
- document consolidated backend for all calculators

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c39f29550832b9a57a5af3af9a051